### PR TITLE
Fix Lexer issue for Format type Protobuf

### DIFF
--- a/src/main/antlr/ConnectorLexer.g4
+++ b/src/main/antlr/ConnectorLexer.g4
@@ -130,7 +130,7 @@ WITHUNWRAP
     ;
 
 FORMAT
-    : 'avro'|'AVRO'|'text'|'TEXT'|'binary'|'BINARY'|'json'|'JSON'|'object'|'OBJECT'|'map'|'MAP'
+    : 'avro'|'AVRO'|'text'|'TEXT'|'binary'|'BINARY'|'json'|'JSON'|'object'|'OBJECT'|'map'|'MAP'|'protobuf'|'PROTOBUF'
     ;
 
 PROJECTTO

--- a/src/test/java/com/datamountaineer/kcql/KcqlTest.java
+++ b/src/test/java/com/datamountaineer/kcql/KcqlTest.java
@@ -801,6 +801,10 @@ public class KcqlTest {
     String syntax4 = String.format("INSERT INTO %s SELECT * FROM %s WITHFORMAT object", table, topic);
     Kcql c4 = Kcql.parse(syntax4);
     assertEquals(c4.getFormatType().toString(), "OBJECT");
+
+    String syntax5 = String.format("INSERT INTO %s SELECT * FROM %s WITHFORMAT protobuf", table, topic);
+    Kcql c5 = Kcql.parse(syntax5);
+    assertEquals(c5.getFormatType().toString(), "PROTOBUF");
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Given that KCQL Format with PROTOBUF is supported, there exists an issue with it being not supported in Lexer. This change holds that fix