### PR TITLE
Fix sink connector link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ FROM   $TOPIC_NAME
      
 ```
 
-* To view how a sink connector (i.e. Cassandra) manage configuration options, refer to
-<a href="http://docs.datamountaineer.com/en/latest/connectors.html">documentation here</a>
+* To view how a sink connector (i.e. AWS S3) manages configuration options, refer to the
+**<a href="https://docs.lenses.io/5.4/connectors/sinks/s3sinkconnector/">documentation here</a>**.
 
-The *SELECT* mode is usefull for target systems that do not support the concept of <namespace> (i.e. a an in-memory
+The *SELECT* mode is useful for target systems that do not support the concept of <namespace> (i.e. a an in-memory
 Key-Value system does not have the concept of a <database>.<table>) and can also be utilized in the socket-streamer
 to peek into KAFKA via websockets and receive the payloads in real time.
 


### PR DESCRIPTION
👋 

As I was testing the [Lenses AWS S3 sink connector](https://docs.lenses.io/5.4/connectors/sinks/s3sinkconnector/) and referencing the KCQL documentation, I noticed that this link is out of date. 

This PR links it to the S3 sink configuration in particular, because it demonstrates the `WITH_FLUSH_*` parameters (which MUST come before `PROPERTIES`, which took me a while to figure out until finding it in the latest docs).

Hoping to make it easier to catch for the next person, let me know what you guys think.

**Edit:** Just found **[this Lenses Slack message](https://lensesio.slack.com/archives/C90QBFWP4/p1704228975579789?thread_ts=1703790235.240119&cid=C90QBFWP4)** confirming that flush parameter ordering matters as well, so it could be useful to have these docs referenced.